### PR TITLE
100 canvas sync advanced form does not allow date selection

### DIFF
--- a/src/components/CanvasSync/AdvancedForm.tsx
+++ b/src/components/CanvasSync/AdvancedForm.tsx
@@ -54,7 +54,7 @@ function AdvancedCanvasForm({ canvasAccessData, formSetter }: { canvasAccessData
     <InputFormFields
       changeHandler={dateChangeHandler}
       type="datetime-local"
-      value={getCanvasAccessDate(new Date(canvasAccessData.start ?? Date.now()))}>
+    >
       Start date
     </InputFormFields>
     <Checkbox


### PR DESCRIPTION
Urgent fix. No review required.

closes #100 